### PR TITLE
Extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
             <artifactId>javassist</artifactId>
             <version>3.18.2-GA</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,29 @@
             <version>1.8.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.4.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.4.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+            <version>3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.18.2-GA</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -79,8 +102,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 

--- a/resources/plugin-settings.template.html
+++ b/resources/plugin-settings.template.html
@@ -20,6 +20,11 @@
     <span class="form_error" ng-show="GOINPUTNAME[sender_email_id].$error.server">{{ GOINPUTNAME[sender_email_id].$error.server }}</span>
 </div>
 <div class="form_item_block">
+    <label>SMTP Username:<span class="asterisk">*</span></label>
+    <input type="text" ng-model="smtp_username" ng-required="true"/>
+    <span class="form_error" ng-show="GOINPUTNAME[smtp_username].$error.server">{{ GOINPUTNAME[smtp_username].$error.server }}</span>
+</div>
+<div class="form_item_block">
     <label>Sender Password:<span class="asterisk">*</span></label>
     <input type="password" ng-model="sender_password" ng-required="true"/>
     <span class="form_error" ng-show="GOINPUTNAME[sender_password].$error.server">{{ GOINPUTNAME[sender_password].$error.server }}</span>

--- a/resources/plugin-settings.template.html
+++ b/resources/plugin-settings.template.html
@@ -29,3 +29,8 @@
     <input type="text" ng-model="receiver_email_id" ng-required="true"/>
     <span class="form_error" ng-show="GOINPUTNAME[receiver_email_id].$error.server">{{ GOINPUTNAME[receiver_email_id].$error.server }}</span>
 </div>
+<div class="form_item_block">
+    <label>Pipeline/Stage/Status filter:<span class="asterisk">*</span></label>
+    <input type="text" ng-model="pipeline_stage_filter" ng-required="true"/>
+    <span class="form_error" ng-show="GOINPUTNAME[pipeline_stage_filter].$error.server">{{ GOINPUTNAME[pipeline_stage_filter].$error.server }}</span>
+</div>

--- a/src/com/tw/go/plugin/BuildState.java
+++ b/src/com/tw/go/plugin/BuildState.java
@@ -1,0 +1,32 @@
+package com.tw.go.plugin;
+
+
+public enum BuildState {
+
+    BUILDING,
+    FAILING,
+    PASSED,
+    FAILED,
+    CANCELLED,
+    UNKNOWN;
+
+    public static BuildState fromRawString(String rawString) {
+        if(rawString == null) {
+            return null;
+        }
+        switch (rawString.toLowerCase()) {
+            case "building":
+                return BUILDING;
+            case "failing":
+                return FAILING;
+            case "passed":
+                return PASSED;
+            case "failed":
+                return FAILED;
+            case "cancelled":
+                return CANCELLED;
+            default:
+                return UNKNOWN;
+        }
+    }
+}

--- a/src/com/tw/go/plugin/EmailNotificationPluginImpl.java
+++ b/src/com/tw/go/plugin/EmailNotificationPluginImpl.java
@@ -102,8 +102,18 @@ public class EmailNotificationPluginImpl implements GoPlugin {
 
             PluginSettings pluginSettings = getPluginSettings();
 
-            SMTPSettings settings = new SMTPSettings(pluginSettings.getSmtpHost(), pluginSettings.getSmtpPort(), pluginSettings.isTls(), pluginSettings.getSenderEmailId(), pluginSettings.getSenderPassword());
-            new SMTPMailSender(settings).send(subject, body, pluginSettings.getReceiverEmailId());
+            String receiverEmailIdString = pluginSettings.getReceiverEmailId();
+
+            String[] receiverEmailIds = new String[] { receiverEmailIdString } ;
+
+            if(receiverEmailIdString.contains(",")) {
+                receiverEmailIds = receiverEmailIdString.split(",");
+            }
+
+            for(String receiverEmailId : receiverEmailIds) {
+                SMTPSettings settings = new SMTPSettings(pluginSettings.getSmtpHost(), pluginSettings.getSmtpPort(), pluginSettings.isTls(), pluginSettings.getSenderEmailId(), pluginSettings.getSenderPassword());
+                new SMTPMailSender(settings).send(subject, body, receiverEmailId);
+            }
 
             LOGGER.info("Successfully delivered an email.");
 

--- a/src/com/tw/go/plugin/EmailNotificationPluginImpl.java
+++ b/src/com/tw/go/plugin/EmailNotificationPluginImpl.java
@@ -31,6 +31,7 @@ public class EmailNotificationPluginImpl implements GoPlugin {
     public static final String PLUGIN_SETTINGS_SMTP_PORT = "smtp_port";
     public static final String PLUGIN_SETTINGS_IS_TLS = "is_tls";
     public static final String PLUGIN_SETTINGS_SENDER_EMAIL_ID = "sender_email_id";
+    public static final String PLUGIN_SETTINGS_SMTP_USERNAME = "smtp_username";
     public static final String PLUGIN_SETTINGS_SENDER_PASSWORD = "sender_password";
     public static final String PLUGIN_SETTINGS_RECEIVER_EMAIL_ID = "receiver_email_id";
     public static final String PLUGIN_SETTINGS_FILTER = "pipeline_stage_filter";
@@ -100,7 +101,7 @@ public class EmailNotificationPluginImpl implements GoPlugin {
             String pipelineName = (String) pipelineMap.get("name");
             String stageName = (String) stageMap.get("name");
             String stageState = (String) stageMap.get("state");
-            
+
             String subject = String.format("%s/%s is/has %s", pipelineName, stageName, stageState);
             String body = String.format("State: %s\nResult: %s\nCreate Time: %s\nLast Transition Time: %s", stageState, stageMap.get("result"), stageMap.get("create-time"), stageMap.get("last-transition-time"));
 
@@ -133,7 +134,7 @@ public class EmailNotificationPluginImpl implements GoPlugin {
                 }
 
                 for (String receiverEmailId : receiverEmailIds) {
-                    SMTPSettings settings = new SMTPSettings(pluginSettings.getSmtpHost(), pluginSettings.getSmtpPort(), pluginSettings.isTls(), pluginSettings.getSenderEmailId(), pluginSettings.getSenderPassword());
+                    SMTPSettings settings = new SMTPSettings(pluginSettings.getSmtpHost(), pluginSettings.getSmtpPort(), pluginSettings.isTls(), pluginSettings.getSenderEmailId(), pluginSettings.getSmtpUsername(), pluginSettings.getSenderPassword());
                     new SMTPMailSender(settings).send(subject, body, receiverEmailId);
                 }
 
@@ -165,8 +166,9 @@ public class EmailNotificationPluginImpl implements GoPlugin {
         response.put(PLUGIN_SETTINGS_SMTP_PORT, createField("SMTP Port", null, true, false, "1"));
         response.put(PLUGIN_SETTINGS_IS_TLS, createField("TLS", null, true, false, "2"));
         response.put(PLUGIN_SETTINGS_SENDER_EMAIL_ID, createField("Sender Email ID", null, true, false, "3"));
-        response.put(PLUGIN_SETTINGS_SENDER_PASSWORD, createField("Sender Password", null, true, true, "4"));
-        response.put(PLUGIN_SETTINGS_FILTER, createField("Pipeline/Stage/Status filter", null, false, false, "5"));
+        response.put(PLUGIN_SETTINGS_SMTP_USERNAME, createField("SMTP Username", null, true, false, "4"));
+        response.put(PLUGIN_SETTINGS_SENDER_PASSWORD, createField("Sender Password", null, true, true, "5"));
+        response.put(PLUGIN_SETTINGS_FILTER, createField("Pipeline/Stage/Status filter", null, false, false, "6"));
         return renderJSON(SUCCESS_RESPONSE_CODE, response);
     }
 
@@ -254,6 +256,7 @@ public class EmailNotificationPluginImpl implements GoPlugin {
         Map<String, String> responseBodyMap = (Map<String, String>) JSONUtils.fromJSON(response.responseBody());
         return new PluginSettings(responseBodyMap.get(PLUGIN_SETTINGS_SMTP_HOST), Integer.parseInt(responseBodyMap.get(PLUGIN_SETTINGS_SMTP_PORT)),
                 Boolean.parseBoolean(responseBodyMap.get(PLUGIN_SETTINGS_IS_TLS)), responseBodyMap.get(PLUGIN_SETTINGS_SENDER_EMAIL_ID),
+                responseBodyMap.get(PLUGIN_SETTINGS_SMTP_USERNAME),
                 responseBodyMap.get(PLUGIN_SETTINGS_SENDER_PASSWORD), responseBodyMap.get(PLUGIN_SETTINGS_RECEIVER_EMAIL_ID),
                 responseBodyMap.get(PLUGIN_SETTINGS_FILTER));
     }

--- a/src/com/tw/go/plugin/Filter.java
+++ b/src/com/tw/go/plugin/Filter.java
@@ -1,0 +1,78 @@
+package com.tw.go.plugin;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+public class Filter {
+
+    private String pipeline;
+    private String stage;
+    private BuildState status;
+
+    public Filter(String pipeline, String stage, String status) {
+        this.pipeline = pipeline;
+        this.stage = stage;
+        this.status = BuildState.fromRawString(status);
+    }
+
+    public boolean matches(String pipeline, String stage, BuildState status) {
+        if(this.pipeline != null) {
+
+            if(this.pipeline.startsWith("*") && this.pipeline.endsWith("*")) {
+                if(pipeline == null || !pipeline.contains(this.pipeline.replaceAll("\\*", ""))) {
+                    return false;
+                }
+            } else if(!this.pipeline.equalsIgnoreCase(pipeline)) {
+                return false;
+            }
+        }
+
+        if(this.stage != null && !this.stage.equalsIgnoreCase(stage)) {
+            return false;
+        }
+
+        if(this.status != null && !this.status.equals(status)){
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean matches(String pipeline, String stage, String rawStatus) {
+        return matches(pipeline, stage, BuildState.fromRawString(rawStatus));
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(pipeline)
+                .append(stage)
+                .append(status)
+                .hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof Filter)) {
+            return false;
+        }
+        Filter otherFilter = (Filter) other;
+
+        return new EqualsBuilder()
+                .append(this.pipeline, otherFilter.pipeline)
+                .append(this.stage, otherFilter.stage)
+                .append(this.status, otherFilter.status)
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        stringBuilder.append("Pipeline: "+pipeline+"\n");
+        stringBuilder.append("Stage: "+stage+"\n");
+        stringBuilder.append("Status: "+status+"\n");
+
+        return stringBuilder.toString();
+    }
+}

--- a/src/com/tw/go/plugin/FilterConverter.java
+++ b/src/com/tw/go/plugin/FilterConverter.java
@@ -1,0 +1,94 @@
+package com.tw.go.plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FilterConverter {
+
+    private static final String FILTER_SEPARATOR = ",";
+    private static final String FILTER_FIELD_SEPARATOR = ":";
+
+    public List<Filter> convertStringToFilterList(String filterConfigString) {
+        ArrayList<Filter> filterList = new ArrayList<>();
+
+        if(filterConfigString == null || "".equals(filterConfigString)) {
+            return filterList;
+        }
+
+        String[] filterConfigList = convertToList(filterConfigString);
+
+        for(String filterConfig : filterConfigList) {
+            Filter converted = convertToFilter(filterConfig);
+            if(converted != null) {
+                filterList.add(converted);
+            }
+        }
+
+        return filterList;
+    }
+
+
+    /**
+     * Assumes a list of values separated by FILTER_SEPARATOR
+     *
+     * Each value will be treated as an individual filter
+     *
+     * E.g.
+     *
+     * "TempTest:cloudformation:building,SmokeTest:cloudformation:failed"
+     * Would become
+     * [
+     * "TempTest:cloudformation:building",
+     * "SmokeTest:cloudformation:failed"
+     * ]
+     */
+    private String[] convertToList(String configList) {
+        if(configList == null || "".equals(configList)) {
+            return new String[0];
+        }
+
+        String[] filterConfigList = new String[] { configList };
+
+        if(configList.contains(FILTER_SEPARATOR)) {
+            filterConfigList = configList.split(FILTER_SEPARATOR);
+        }
+
+        return filterConfigList;
+    }
+
+    /**
+     * Assumes each filter has at most 3 fields (pipeline/stage/status) split by FILTER_FIELD_SEPARATOR
+     *
+     * E.g.
+     *
+     * TempTestDeploy:cloudformation:building
+     *
+     * becomes a filter object with the 3 values set appropriately
+     */
+    private Filter convertToFilter(String filterConfig) {
+        if(filterConfig == null || "".equals(filterConfig)) {
+            return null;
+        }
+        String pipeline = filterConfig;
+        String stage = null;
+        String status = null;
+
+        if(filterConfig.contains(FILTER_FIELD_SEPARATOR)) {
+            String[] filterConfigParts = filterConfig.split(FILTER_FIELD_SEPARATOR);
+
+            pipeline = filterConfigParts[0];
+
+            if(filterConfigParts.length > 1) {
+                stage = filterConfigParts[1];
+            }
+
+            if(filterConfigParts.length > 2) {
+                status = filterConfigParts[2];
+            }
+
+        }
+
+        return new Filter(pipeline, stage, status);
+    }
+
+}

--- a/src/com/tw/go/plugin/PluginSettings.java
+++ b/src/com/tw/go/plugin/PluginSettings.java
@@ -7,15 +7,17 @@ public class PluginSettings {
     private int smtpPort;
     private boolean tls;
     private String senderEmailId;
+    private String smtpUsername;
     private String senderPassword;
     private String receiverEmailId;
     private List<Filter> filterList;
 
-    public PluginSettings(String smtpHost, int smtpPort, boolean tls, String senderEmailId, String senderPassword, String receiverEmailId, String filterString) {
+    public PluginSettings(String smtpHost, int smtpPort, boolean tls, String senderEmailId, String smtpUsername, String senderPassword, String receiverEmailId, String filterString) {
         this.smtpHost = smtpHost;
         this.smtpPort = smtpPort;
         this.tls = tls;
         this.senderEmailId = senderEmailId;
+        this.smtpUsername = smtpUsername;
         this.senderPassword = senderPassword;
         this.receiverEmailId = receiverEmailId;
         FilterConverter filterController = new FilterConverter();
@@ -107,5 +109,9 @@ public class PluginSettings {
         result = 31 * result + (receiverEmailId != null ? receiverEmailId.hashCode() : 0);
         result = 31 * result + (filterList != null ? filterList.hashCode() : 0);
         return result;
+    }
+
+    public String getSmtpUsername() {
+        return smtpUsername;
     }
 }

--- a/src/com/tw/go/plugin/PluginSettings.java
+++ b/src/com/tw/go/plugin/PluginSettings.java
@@ -1,5 +1,7 @@
 package com.tw.go.plugin;
 
+import java.util.List;
+
 public class PluginSettings {
     private String smtpHost;
     private int smtpPort;
@@ -7,14 +9,17 @@ public class PluginSettings {
     private String senderEmailId;
     private String senderPassword;
     private String receiverEmailId;
+    private List<Filter> filterList;
 
-    public PluginSettings(String smtpHost, int smtpPort, boolean tls, String senderEmailId, String senderPassword, String receiverEmailId) {
+    public PluginSettings(String smtpHost, int smtpPort, boolean tls, String senderEmailId, String senderPassword, String receiverEmailId, String filterString) {
         this.smtpHost = smtpHost;
         this.smtpPort = smtpPort;
         this.tls = tls;
         this.senderEmailId = senderEmailId;
         this.senderPassword = senderPassword;
         this.receiverEmailId = receiverEmailId;
+        FilterConverter filterController = new FilterConverter();
+        this.filterList = filterController.convertStringToFilterList(filterString);
     }
 
     public String getSmtpHost() {
@@ -65,6 +70,10 @@ public class PluginSettings {
         this.receiverEmailId = receiverEmailId;
     }
 
+    public List<Filter> getFilterList() {
+        return filterList;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -80,7 +89,10 @@ public class PluginSettings {
             return false;
         if (senderPassword != null ? !senderPassword.equals(that.senderPassword) : that.senderPassword != null)
             return false;
-        if (smtpHost != null ? !smtpHost.equals(that.smtpHost) : that.smtpHost != null) return false;
+        if (smtpHost != null ? !smtpHost.equals(that.smtpHost) : that.smtpHost != null)
+            return false;
+        if(filterList != null ? !filterList.equals(that.filterList) : that.filterList != null)
+            return false;
 
         return true;
     }
@@ -93,6 +105,7 @@ public class PluginSettings {
         result = 31 * result + (senderEmailId != null ? senderEmailId.hashCode() : 0);
         result = 31 * result + (senderPassword != null ? senderPassword.hashCode() : 0);
         result = 31 * result + (receiverEmailId != null ? receiverEmailId.hashCode() : 0);
+        result = 31 * result + (filterList != null ? filterList.hashCode() : 0);
         return result;
     }
 }

--- a/src/com/tw/go/plugin/SMTPMailSender.java
+++ b/src/com/tw/go/plugin/SMTPMailSender.java
@@ -41,9 +41,9 @@ public class SMTPMailSender {
         Transport transport = null;
         try {
             Properties properties = mailProperties();
-            Session session = createSession(properties, smtpSettings.getFromEmailId(), smtpSettings.getPassword());
+            Session session = createSession(properties, smtpSettings.getSmtpUsername(), smtpSettings.getPassword());
             transport = session.getTransport();
-            transport.connect(smtpSettings.getHostName(), nullIfEmpty(smtpSettings.getFromEmailId()), nullIfEmpty(smtpSettings.getPassword()));
+            transport.connect(smtpSettings.getHostName(), nullIfEmpty(smtpSettings.getSmtpUsername()), nullIfEmpty(smtpSettings.getPassword()));
             MimeMessage message = createMessage(session, smtpSettings.getFromEmailId(), toEmailId, subject, body);
             transport.sendMessage(message, message.getRecipients(TO));
         } catch (Exception e) {

--- a/src/com/tw/go/plugin/SMTPSettings.java
+++ b/src/com/tw/go/plugin/SMTPSettings.java
@@ -6,13 +6,15 @@ public class SMTPSettings {
     private boolean tls;
     private String fromEmailId;
     private String password;
+    private String smtpUsername;
 
-    public SMTPSettings(String hostName, int port, boolean tls, String fromEmailId, String password) {
+    public SMTPSettings(String hostName, int port, boolean tls, String fromEmailId, String smtpUsername, String password) {
         this.hostName = hostName;
         this.port = port;
         this.tls = tls;
-        this.fromEmailId = fromEmailId;
         this.password = password;
+        this.smtpUsername = smtpUsername;
+        this.fromEmailId = fromEmailId;
     }
 
     public String getHostName() {
@@ -35,6 +37,8 @@ public class SMTPSettings {
         return password;
     }
 
+    public String getSmtpUsername() { return smtpUsername; }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -47,6 +51,7 @@ public class SMTPSettings {
         if (fromEmailId != null ? !fromEmailId.equals(that.fromEmailId) : that.fromEmailId != null) return false;
         if (hostName != null ? !hostName.equals(that.hostName) : that.hostName != null) return false;
         if (password != null ? !password.equals(that.password) : that.password != null) return false;
+        if (smtpUsername != null ? !smtpUsername.equals(that.smtpUsername) : that.smtpUsername != null) return false;
 
         return true;
     }
@@ -58,6 +63,7 @@ public class SMTPSettings {
         result = 31 * result + (tls ? 1 : 0);
         result = 31 * result + (fromEmailId != null ? fromEmailId.hashCode() : 0);
         result = 31 * result + (password != null ? password.hashCode() : 0);
+        result = 31 * result + (smtpUsername != null ? smtpUsername.hashCode() : 0);
         return result;
     }
 }

--- a/test/com/tw/go/plugin/EmailNotificationPluginImplUnitTest.java
+++ b/test/com/tw/go/plugin/EmailNotificationPluginImplUnitTest.java
@@ -80,6 +80,7 @@ public class EmailNotificationPluginImplUnitTest {
         settingsResponseMap.put("is_tls", "0");
         settingsResponseMap.put("sender_email_id", "test-smtp-sender");
         settingsResponseMap.put("sender_password", "test-smtp-password");
+        settingsResponseMap.put("smtp_username", "test-smtp-username");
         settingsResponseMap.put("receiver_email_id", "test-smtp-receiver");
     }
 
@@ -151,7 +152,7 @@ public class EmailNotificationPluginImplUnitTest {
         emailNotificationPlugin.handle(requestFromServer);
 
         verify(mockTransport).sendMessage(any(Message.class), eq( new Address[] { new InternetAddress("test-email@test.co.uk") } ));
-        verify(mockTransport, times(1)).connect(eq("test-smtp-host"), eq("test-smtp-sender"), eq("test-smtp-password"));
+        verify(mockTransport, times(1)).connect(eq("test-smtp-host"), eq("test-smtp-username"), eq("test-smtp-password"));
         verify(mockTransport, times(1)).close();
         verifyNoMoreInteractions(mockTransport);
     }
@@ -170,7 +171,7 @@ public class EmailNotificationPluginImplUnitTest {
 
         verify(mockTransport).sendMessage(any(Message.class), eq( new Address[] { new InternetAddress("test-email@test.co.uk") } ));
         verify(mockTransport).sendMessage(any(Message.class), eq( new Address[] { new InternetAddress("test-email-2@test.co.uk") } ));
-        verify(mockTransport, times(2)).connect(eq("test-smtp-host"), eq("test-smtp-sender"), eq("test-smtp-password"));
+        verify(mockTransport, times(2)).connect(eq("test-smtp-host"), eq("test-smtp-username"), eq("test-smtp-password"));
         verify(mockTransport, times(2)).close();
         verifyNoMoreInteractions(mockTransport);
     }

--- a/test/com/tw/go/plugin/EmailNotificationPluginImplUnitTest.java
+++ b/test/com/tw/go/plugin/EmailNotificationPluginImplUnitTest.java
@@ -1,0 +1,238 @@
+package com.tw.go.plugin;
+
+import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
+import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
+import com.thoughtworks.go.plugin.api.request.GoApiRequest;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.GoApiResponse;
+import com.tw.go.plugin.util.JSONUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.mail.*;
+import javax.mail.internet.InternetAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Session.class)
+public class EmailNotificationPluginImplUnitTest {
+
+    @Mock
+    private GoApplicationAccessor goApplicationAccessor;
+
+    @Mock
+    private Session mockSession;
+
+    @Mock
+    private Transport mockTransport;
+
+    @Mock
+    private Properties mockProperties;
+
+    private Map<String, Object> settingsResponseMap;
+
+    private Map<String, Object> stateChangeResponseMap;
+
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        mockStatic(Session.class);
+
+        when(mockSession.getTransport()).thenReturn(mockTransport);
+        when(mockSession.getTransport(any(Address.class))).thenReturn(mockTransport);
+        when(mockSession.getTransport(any(Provider.class))).thenReturn(mockTransport);
+
+        when(mockSession.getProperties()).thenReturn(mockProperties);
+
+        when(Session.getInstance(any(Properties.class))).thenReturn(mockSession);
+        when(Session.getInstance(any(Properties.class), any(Authenticator.class))).thenReturn(mockSession);
+
+
+        emailNotificationPlugin = new EmailNotificationPluginImpl();
+        emailNotificationPlugin.initializeGoApplicationAccessor(goApplicationAccessor);
+    }
+
+    @Before
+    public void setupDefaultSettingResponse() {
+        settingsResponseMap = new HashMap<>();
+
+        settingsResponseMap.put("smtp_host", "test-smtp-host");
+        settingsResponseMap.put("smtp_port", "25");
+        settingsResponseMap.put("is_tls", "0");
+        settingsResponseMap.put("sender_email_id", "test-smtp-sender");
+        settingsResponseMap.put("sender_password", "test-smtp-password");
+        settingsResponseMap.put("receiver_email_id", "test-smtp-receiver");
+    }
+
+    @Before
+    public void setupDefaultStateChangeResponseMap() {
+        Map<String, Object> stageResponseMap = new HashMap<>();
+
+        stageResponseMap.put("name", "test-stage-name");
+        stageResponseMap.put("counter", "test-counter");
+        stageResponseMap.put("state", "test-state");
+        stageResponseMap.put("result", "test-result");
+        stageResponseMap.put("last-transition-time", "test-last-transition-time");
+        stageResponseMap.put("create-time", "test-last-transition-time");
+
+
+        Map<String, Object> pipelineMap = new HashMap<>();
+
+        pipelineMap.put("stage", stageResponseMap);
+        pipelineMap.put("name", "test-pipeline-name");
+        pipelineMap.put("counter", "test-pipeline-counter");
+
+        stateChangeResponseMap = new HashMap<>();
+
+        stateChangeResponseMap.put("pipeline", pipelineMap);
+    }
+
+    private EmailNotificationPluginImpl emailNotificationPlugin;
+
+    @Test
+    public void testStageNotificationRequestsSettings() throws Exception {
+        GoApiResponse settingsResponse = testSettingsResponse();
+
+        when(goApplicationAccessor.submit(eq(testSettingsRequest()))).thenReturn(settingsResponse);
+
+        GoPluginApiRequest requestFromServer = testStageChangeRequestFromServer();
+
+        emailNotificationPlugin.handle(requestFromServer);
+
+        final ArgumentCaptor<GoApiRequest> settingsRequestCaptor = ArgumentCaptor.forClass(GoApiRequest.class);
+
+        verify(goApplicationAccessor).submit(settingsRequestCaptor.capture());
+
+        final GoApiRequest actualSettingsRequest = settingsRequestCaptor.getValue();
+
+        assertEquals(testSettingsRequest().api(), actualSettingsRequest.api());
+        assertEquals(testSettingsRequest().apiVersion(), actualSettingsRequest.apiVersion());
+
+        GoPluginIdentifier actualGoPluginIdentifier = actualSettingsRequest.pluginIdentifier();
+
+        assertNotNull(actualGoPluginIdentifier);
+
+        assertEquals(testSettingsRequest().pluginIdentifier().getExtension(), actualGoPluginIdentifier.getExtension());
+        assertEquals(testSettingsRequest().pluginIdentifier().getSupportedExtensionVersions(), actualGoPluginIdentifier.getSupportedExtensionVersions());
+        assertEquals(testSettingsRequest().requestBody(), actualSettingsRequest.requestBody());
+        assertEquals(testSettingsRequest().requestHeaders(), actualSettingsRequest.requestHeaders());
+        assertEquals(testSettingsRequest().requestParameters(), actualSettingsRequest.requestParameters());
+    }
+
+    @Test
+    public void testASingleEmailAddressSendsEmail() throws Exception {
+        settingsResponseMap.put("receiver_email_id", "test-email@test.co.uk");
+
+        GoApiResponse settingsResponse = testSettingsResponse();
+
+        when(goApplicationAccessor.submit(any(GoApiRequest.class))).thenReturn(settingsResponse);
+
+        GoPluginApiRequest requestFromServer = testStageChangeRequestFromServer();
+
+        emailNotificationPlugin.handle(requestFromServer);
+
+        verify(mockTransport).sendMessage(any(Message.class), eq( new Address[] { new InternetAddress("test-email@test.co.uk") } ));
+        verify(mockTransport, times(1)).connect(eq("test-smtp-host"), eq("test-smtp-sender"), eq("test-smtp-password"));
+        verify(mockTransport, times(1)).close();
+        verifyNoMoreInteractions(mockTransport);
+    }
+
+    @Test
+    public void testMultipleEmailAddressSendsEmail() throws Exception {
+        settingsResponseMap.put("receiver_email_id", "test-email@test.co.uk, test-email-2@test.co.uk");
+
+        GoApiResponse settingsResponse = testSettingsResponse();
+
+        when(goApplicationAccessor.submit(any(GoApiRequest.class))).thenReturn(settingsResponse);
+
+        GoPluginApiRequest requestFromServer = testStageChangeRequestFromServer();
+
+        emailNotificationPlugin.handle(requestFromServer);
+
+        verify(mockTransport).sendMessage(any(Message.class), eq( new Address[] { new InternetAddress("test-email@test.co.uk") } ));
+        verify(mockTransport).sendMessage(any(Message.class), eq( new Address[] { new InternetAddress("test-email-2@test.co.uk") } ));
+        verify(mockTransport, times(2)).connect(eq("test-smtp-host"), eq("test-smtp-sender"), eq("test-smtp-password"));
+        verify(mockTransport, times(2)).close();
+        verifyNoMoreInteractions(mockTransport);
+    }
+
+
+    private GoPluginApiRequest testStageChangeRequestFromServer() {
+        GoPluginApiRequest requestFromGoServer = mock(GoPluginApiRequest.class);
+
+        when(requestFromGoServer.requestName()).thenReturn("stage-status");
+
+        when(requestFromGoServer.requestBody()).thenReturn(JSONUtils.toJSON(stateChangeResponseMap));
+
+        return requestFromGoServer;
+    }
+
+    private static GoApiRequest testSettingsRequest() {
+
+        final Map<String, Object> requestMap = new HashMap<String, Object>();
+        requestMap.put("plugin-id", "email.notifier");
+
+        final String responseBody = JSONUtils.toJSON(requestMap);
+
+        return new GoApiRequest() {
+            @Override
+            public String api() {
+                return "go.processor.plugin-settings.get";
+            }
+
+            @Override
+            public String apiVersion() {
+                return "1.0";
+            }
+
+            @Override
+            public GoPluginIdentifier pluginIdentifier() {
+                return new GoPluginIdentifier("notification", Collections.singletonList("1.0"));
+            }
+
+            @Override
+            public Map<String, String> requestParameters() {
+                return null;
+            }
+
+            @Override
+            public Map<String, String> requestHeaders() {
+                return null;
+            }
+
+            @Override
+            public String requestBody() {
+                return responseBody;
+            }
+        };
+    }
+
+    private GoApiResponse testSettingsResponse() {
+        GoApiResponse settingsResponse = mock(GoApiResponse.class);
+
+        when(settingsResponse.responseBody()).thenReturn(JSONUtils.toJSON(settingsResponseMap));
+
+        return settingsResponse;
+    }
+
+
+}

--- a/test/com/tw/go/plugin/FilterConverterTest.java
+++ b/test/com/tw/go/plugin/FilterConverterTest.java
@@ -1,0 +1,111 @@
+package com.tw.go.plugin;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class FilterConverterTest {
+
+    private FilterConverter filterConverter;
+
+    @Before
+    public void setup() {
+        this.filterConverter = new FilterConverter();
+    }
+
+    @Test
+    public void testSingleFilterConverted() {
+        String settingInput = "TempTestBaseInf:cloudformation:building";
+
+        List<Filter> filterList = filterConverter.convertStringToFilterList(settingInput);
+
+        assertNotNull(filterList);
+        assertEquals(1, filterList.size());
+
+        Filter expectedFilter = new Filter("TempTestBaseInf", "cloudformation", "building");
+
+        assertEquals(expectedFilter, filterList.get(0));
+    }
+
+    @Test
+    public void testMultipleFiltersConverted() {
+        String settingInput = "TempTestBaseInf:cloudformation:building,SmokeTestNetworkInf:ansible:failed";
+
+        List<Filter> filterList = filterConverter.convertStringToFilterList(settingInput);
+
+        assertNotNull(filterList);
+        assertEquals(2, filterList.size());
+
+        Filter firstExpectedFilter = new Filter("TempTestBaseInf", "cloudformation", "building");
+        Filter secondExpectedFilter = new Filter("SmokeTestNetworkInf", "ansible", "failed");
+
+        assertEquals(firstExpectedFilter, filterList.get(0));
+        assertEquals(secondExpectedFilter, filterList.get(1));
+    }
+
+    @Test
+    public void testMultipleFiltersConvertedWithExtraCommas() {
+        String settingInput = ",,TempTestBaseInf:cloudformation:building,,,,SmokeTestNetworkInf:ansible:failed,,,";
+
+        List<Filter> filterList = filterConverter.convertStringToFilterList(settingInput);
+
+        assertNotNull(filterList);
+        assertEquals(2, filterList.size());
+
+        Filter firstExpectedFilter = new Filter("TempTestBaseInf", "cloudformation", "building");
+        Filter secondExpectedFilter = new Filter("SmokeTestNetworkInf", "ansible", "failed");
+
+        assertEquals(firstExpectedFilter, filterList.get(0));
+        assertEquals(secondExpectedFilter, filterList.get(1));
+    }
+
+    @Test
+    public void testPartiallyDefinedFilter() {
+        String settingInput = "TempTestBaseInf";
+
+        List<Filter> filterList = filterConverter.convertStringToFilterList(settingInput);
+
+        assertNotNull(filterList);
+        assertEquals(1, filterList.size());
+
+        Filter expectedFilter = new Filter("TempTestBaseInf", null, null);
+
+        assertEquals(expectedFilter, filterList.get(0));
+    }
+
+    @Test
+    public void testMultiplePartiallyDefinedFilters() {
+        String settingInput = "TempTestBaseInf,SmokeTest:cloudformation";
+
+        List<Filter> filterList = filterConverter.convertStringToFilterList(settingInput);
+
+        assertNotNull(filterList);
+        assertEquals(2, filterList.size());
+
+        Filter firstExpectedFilter = new Filter("TempTestBaseInf", null, null);
+        Filter secondExpectedFilter = new Filter("SmokeTest", "cloudformation", null);
+
+        assertEquals(firstExpectedFilter, filterList.get(0));
+        assertEquals(secondExpectedFilter, filterList.get(1));
+    }
+
+    @Test
+    public void testConvertMultipleFiltersWithWildcards() {
+        String settingInput = "*BaseInf*:cloudformation:failed,*NetworkInf*:cloudformation:building";
+
+        List<Filter> filterList = filterConverter.convertStringToFilterList(settingInput);
+
+        assertNotNull(filterList);
+        assertEquals(2, filterList.size());
+
+        Filter firstExpectedFilter = new Filter("*BaseInf*", "cloudformation", "failed");
+        Filter secondExpectedFilter = new Filter("*NetworkInf*", "cloudformation", "building");
+
+        assertEquals(firstExpectedFilter, filterList.get(0));
+        assertEquals(secondExpectedFilter, filterList.get(1));
+    }
+}

--- a/test/com/tw/go/plugin/FilterTest.java
+++ b/test/com/tw/go/plugin/FilterTest.java
@@ -1,0 +1,61 @@
+package com.tw.go.plugin;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FilterTest {
+
+    @Test
+    public void testSimpleFilterIsMatched() {
+        Filter testFilter = new Filter("SmokeTestBaseInf", "cloudformation", "building");
+
+        Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "cloudformation", BuildState.BUILDING));
+        Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "cloudformation", "building"));
+
+        Assert.assertFalse(testFilter.matches("SmokeTestBaseInf", "cloudformation", BuildState.CANCELLED));
+        Assert.assertFalse(testFilter.matches("SmokeTestBaseInf", "cloudformation", BuildState.FAILED));
+        Assert.assertFalse(testFilter.matches("SmokeTestBaseInf", "cloudformation", BuildState.FAILING));
+        Assert.assertFalse(testFilter.matches("SmokeTestBaseInf", "cloudformation", BuildState.PASSED));
+        Assert.assertFalse(testFilter.matches("SmokeTestBaseInf", "cloudformation", BuildState.UNKNOWN));
+    }
+
+    @Test
+    public void testFilterWithNullBuildStateMatchesAllStates() {
+        Filter testFilter = new Filter("SmokeTestBaseInf", "cloudformation", null);
+
+        for(BuildState currentState : BuildState.values()) {
+            Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "cloudformation", currentState));
+            Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "ClOuDfOrMaTiOn", currentState));
+
+        }
+    }
+
+    @Test
+    public void testFilterWithNullStageNameAndBuildStateMatchesAllStates() {
+        Filter testFilter = new Filter("SmokeTestBaseInf", null, null);
+
+        for(BuildState currentState : BuildState.values()) {
+            Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", null, currentState));
+        }
+    }
+
+    @Test
+    public void testFilterWithNullStageNameAndBuildStateMatchesAllStageNames() {
+        Filter testFilter = new Filter("SmokeTestBaseInf", null, null);
+
+        Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", null, BuildState.BUILDING));
+        Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "cloudformation", BuildState.BUILDING));
+        Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "CLOUDforMATION", BuildState.BUILDING));
+        Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "somethingrandom", BuildState.BUILDING));
+    }
+
+    @Test
+    public void testFilterWithWilcardPipelineNameMatchesAllPipelines() {
+        Filter testFilter = new Filter("*BaseInf*", "cloudformation", "building");
+
+        Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "cloudformation", BuildState.BUILDING));
+        Assert.assertTrue(testFilter.matches("TempTestBaseInf", "cloudformation", BuildState.BUILDING));
+        Assert.assertTrue(testFilter.matches("ProductionBaseInf", "cloudformation", BuildState.BUILDING));
+    }
+}

--- a/test/com/tw/go/plugin/SMTPMailSenderTest.java
+++ b/test/com/tw/go/plugin/SMTPMailSenderTest.java
@@ -7,7 +7,7 @@ public class SMTPMailSenderTest {
     public void shouldSendEmail() {
         String emailId = "";
         String password = "";
-        SMTPSettings settings = new SMTPSettings("smtp.gmail.com", 587, true, emailId, password);
+        SMTPSettings settings = new SMTPSettings("smtp.gmail.com", 587, true, emailId, emailId, password);
         new SMTPMailSender(settings).send("subject", "body", emailId);
     }
 }


### PR DESCRIPTION
- Enhance the notifier plugin so if there is more than one email address separated by a comma, it will send an email to each address

- Add unit tests to the notifier plugin - started with one testing the settings then did one for the new functionality

- Ensure you can set a filter on which pipelines should actually trigger an email to be sent

- Ensure you can set a SMTP username separately to the address that the email will be from

This plugin waits for all notifications of change from the go-server and sends an email based on that.
I've added a few bits of functionality:
a) Allows the "to-address" to be a comma separated list of values, so can be sent to more than one person
b) Allowed you to set the smtp username separately to the email address that is used as the "from" address (required by AWS SES)
c) Added a 'filter' configuration option which allows you to add a comma separated list of items you want to get notified about
E.g.
*BaseInf*:cloudformation:building
would send an email everytime any pipeline whos name contains BaseInf has a stage called cloudformation that is set to building.
*BaseInf*:cloudformation:building,*NetworkInf*:deployRedis:failed
Would do the same as above, but also send an email for any pipelines whos name contains NetworkInf, and has a stage called deployRedis that has failed.
*BaseInf*
by itself would match all stages and all build states
*BaseInf*:cloudformation
Would match all build states for that pipeline name and stage