### PR TITLE
Add regex for pipeline and stage filters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,19 +54,19 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.8.5</version>
+            <version>2.18.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>1.4.9</version>
+            <version>2.0.0-RC.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>1.4.9</version>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.0-RC.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/com/tw/go/plugin/Filter.java
+++ b/src/com/tw/go/plugin/Filter.java
@@ -2,6 +2,9 @@ package com.tw.go.plugin;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.util.regex.PatternSyntaxException;
 
 public class Filter {
 
@@ -16,18 +19,56 @@ public class Filter {
     }
 
     public boolean matches(String pipeline, String stage, BuildState status) {
-        if(this.pipeline != null) {
+        boolean pipelineIsRegex;
+        boolean stageIsRegex;
 
-            if(this.pipeline.startsWith("*") && this.pipeline.endsWith("*")) {
-                if(pipeline == null || !pipeline.contains(this.pipeline.replaceAll("\\*", ""))) {
-                    return false;
-                }
-            } else if(!this.pipeline.equalsIgnoreCase(pipeline)) {
-                return false;
+        //Check if pipeline string is a regex
+        try {
+            if(this.pipeline != null) {
+                Pattern.compile(this.pipeline);
+                pipelineIsRegex = true;
+            } else {
+                pipelineIsRegex = false;
             }
+        } catch (PatternSyntaxException e) {
+            pipelineIsRegex = false;
         }
 
-        if(this.stage != null && !this.stage.equalsIgnoreCase(stage)) {
+        //Check if stage string is a regex
+        try {
+            if(this.stage != null) {
+                Pattern.compile(this.stage);
+                stageIsRegex = true;
+            } else {
+                stageIsRegex = false;
+            }
+        } catch (PatternSyntaxException e) {
+            stageIsRegex = false;
+        }
+
+        if(pipelineIsRegex) {
+            Pattern pat = Pattern.compile(this.pipeline,Pattern.CASE_INSENSITIVE);
+            Matcher m = pat.matcher(pipeline);
+
+            if(!m.find()) {
+                return false;
+            }
+        } else if(this.pipeline.startsWith("*") && this.pipeline.endsWith("*")) {
+            if(pipeline == null || !pipeline.contains(this.pipeline.replaceAll("\\*", ""))) {
+                return false;
+            }
+        } else if(this.pipeline != null && !this.pipeline.equalsIgnoreCase(pipeline)) {
+            return false;
+        }
+
+        if(stageIsRegex) {
+            Pattern pat = Pattern.compile(this.stage,Pattern.CASE_INSENSITIVE);
+            Matcher m = pat.matcher(stage);
+
+            if(!m.find()) {
+                return false;
+            }
+        } else if(this.stage != null && !this.stage.equalsIgnoreCase(stage)) {
             return false;
         }
 

--- a/test/com/tw/go/plugin/EmailNotificationPluginImplUnitTest.java
+++ b/test/com/tw/go/plugin/EmailNotificationPluginImplUnitTest.java
@@ -24,8 +24,8 @@ import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;

--- a/test/com/tw/go/plugin/FilterTest.java
+++ b/test/com/tw/go/plugin/FilterTest.java
@@ -27,7 +27,6 @@ public class FilterTest {
         for(BuildState currentState : BuildState.values()) {
             Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "cloudformation", currentState));
             Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "ClOuDfOrMaTiOn", currentState));
-
         }
     }
 
@@ -56,6 +55,33 @@ public class FilterTest {
 
         Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "cloudformation", BuildState.BUILDING));
         Assert.assertTrue(testFilter.matches("TempTestBaseInf", "cloudformation", BuildState.BUILDING));
+        Assert.assertTrue(testFilter.matches("ProductionBaseInf", "cloudformation", BuildState.BUILDING));
+    }
+
+    @Test
+    public void testFilterWithRegexPipelineNameMatchesPipelines() {
+        Filter testFilter = new Filter(".*Inf", "cloudformation", "building");
+
+        Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "cloudformation", BuildState.BUILDING));
+        Assert.assertTrue(testFilter.matches("TempTestBaseInf", "cloudformation", BuildState.BUILDING));
+        Assert.assertTrue(testFilter.matches("ProductionBaseInf", "cloudformation", BuildState.BUILDING));
+    }
+
+    @Test
+    public void testFilterWithRegexStageNameMatchesStages() {
+        Filter testFilter = new Filter("SmokeTestBaseInf", ".*formation", "building");
+
+        Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "bananaformation", BuildState.BUILDING));
+        Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "pickleformation", BuildState.BUILDING));
+        Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "cloudformation", BuildState.BUILDING));
+    }
+
+    @Test
+    public void testFilterWithRegexStageAndPipelineNameMatchesStages() {
+        Filter testFilter = new Filter(".*BaseInf", ".*formation", "building");
+
+        Assert.assertTrue(testFilter.matches("SmokeTestBaseInf", "bananaformation", BuildState.BUILDING));
+        Assert.assertTrue(testFilter.matches("TempTestBaseInf", "pickleformation", BuildState.BUILDING));
         Assert.assertTrue(testFilter.matches("ProductionBaseInf", "cloudformation", BuildState.BUILDING));
     }
 }


### PR DESCRIPTION
I've updated the single wildcard for pipelines to include full regex on the filters for both pipelines and stages. Unit tests updated and passing. Also tested in live GoCD instance.