### PR TITLE
[Sakthivel/Vishnu] Fix session factory instance null pointer exception

### DIFF
--- a/src/main/java/com/tw/go/plugin/EmailNotificationPluginImpl.java
+++ b/src/main/java/com/tw/go/plugin/EmailNotificationPluginImpl.java
@@ -70,6 +70,7 @@ public class EmailNotificationPluginImpl implements GoPlugin {
     @Override
     public void initializeGoApplicationAccessor(GoApplicationAccessor goApplicationAccessor) {
         this.goApplicationAccessor = goApplicationAccessor;
+        this.sessionFactory = new SessionFactory();
     }
 
     @Override


### PR DESCRIPTION
This fixes the error, `java.lang.NullPointerException: Cannot invoke "com.tw.go.plugin.SessionFactory.getInstance(java.util.Properties, javax.mail.Authenticator)" because "this.sessionFactory" is null` thrown when creating a session wrapper at https://github.com/gocd-contrib/email-notifier/blob/68a303668e619403250d136ef7822fef4c2a39c9/src/main/java/com/tw/go/plugin/SMTPMailSender.java#L91

We are able to receive email notification after this fix.
